### PR TITLE
Fix auxiliary equipment control enable bit

### DIFF
--- a/src/pycompool/controller.py
+++ b/src/pycompool/controller.py
@@ -241,8 +241,8 @@ class PoolController:
         else:
             primary_equip = current_primary_equip & ~(1 << bit_position)
 
-        # Use bit 0 to enable primary equipment field
-        enable_bits = 1 << 0
+        # Use bit 2 to enable primary equipment field
+        enable_bits = 1 << 2
 
         packet = create_command_packet(
             primary_equip=primary_equip,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -478,7 +478,7 @@ class TestPoolController:
             assert len(call_args) == 17  # Command packet length
             assert call_args[:2] == b"\xFF\xAA"  # Sync bytes
             assert call_args[8] == 0x01  # Primary equip byte (bit 0 set)
-            assert call_args[14] == 0x01  # Enable bit 0 for primary equip
+            assert call_args[14] == 0x04  # Enable bit 2 for primary equip
 
     @patch('pycompool.controller.SerialConnection')
     def test_aux_equipment_preserves_other_states(self, mock_connection_class):


### PR DESCRIPTION
## Summary
- Fix auxiliary equipment control to use enable bit 2 instead of bit 0
- Update corresponding test to expect correct enable bit value
- Matches working Node.js implementation behavior

## Test plan
- [x] Updated unit test passes
- [x] All existing tests continue to pass
- [x] Code passes linting and type checking

The issue was identified by comparing with the Node.js reference implementation, which uses `enableBit(2)` for auxiliary equipment control.

🤖 Generated with [Claude Code](https://claude.ai/code)