### PR TITLE
Fix auxiliary equipment control with proper toggle logic

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,8 +19,11 @@ controller.set_spa_temperature('104f')
 # Set heater mode
 controller.set_heater_mode('heater', 'pool')
 
-# Control auxiliary equipment
-controller.set_aux_equipment(1, True)  # Turn on aux1
+# Control auxiliary equipment (smart toggle)
+controller.set_aux_equipment(1, True)  # Turn on aux1 (only if currently off)
+
+# Direct toggle operations
+controller.toggle_aux_equipment(1)  # Always toggle aux1 regardless of state
 
 # Get system status
 status = controller.get_status()
@@ -96,22 +99,54 @@ Set the heater/solar mode for pool or spa.
 
 ##### set_aux_equipment(aux_num: int, state: bool, verbose: bool = False) -> bool
 
-Set the state of an auxiliary equipment circuit.
+Set the state of an auxiliary equipment circuit using intelligent toggle logic.
+
+The hardware only supports toggling circuits, so this method reads the current state from heartbeat packets and only sends a toggle command if the current state differs from the desired state.
 
 **Parameters:**
 - `aux_num`: Auxiliary circuit number (1-8)
 - `state`: `True` to turn on, `False` to turn off
 - `verbose`: Enable verbose packet output
 
+**Returns:** `True` if ACK received or no action needed, `False` if command failed
+
+**Behavior:**
+- Reads current aux state from heartbeat packet (`aux{N}_on` field)
+- Only sends toggle command if current state ≠ desired state
+- Returns `True` immediately if already in desired state (no-op)
+- Shows status transition: `"Aux1 OFF → ON — ✓ ACK"`
+
+**Example:**
+```python
+# Turn on aux1 (only if currently off)
+success = controller.set_aux_equipment(1, True)
+
+# Turn off aux2 with verbose output  
+success = controller.set_aux_equipment(2, False, verbose=True)
+
+# If aux1 is already on, this returns True immediately with no command sent
+success = controller.set_aux_equipment(1, True)  # "Aux1 already ON — no action needed"
+```
+
+##### toggle_aux_equipment(aux_num: int, verbose: bool = False) -> bool
+
+Toggle an auxiliary equipment circuit regardless of current state.
+
+This method always sends a toggle command without checking current state, matching the Node.js reference implementation behavior.
+
+**Parameters:**
+- `aux_num`: Auxiliary circuit number (1-8)  
+- `verbose`: Enable verbose packet output
+
 **Returns:** `True` if ACK received, `False` otherwise
 
 **Example:**
 ```python
-# Turn on aux1
-success = controller.set_aux_equipment(1, True)
+# Always toggle aux1 (turns on if off, off if on)
+success = controller.toggle_aux_equipment(1)
 
-# Turn off aux2 with verbose output
-success = controller.set_aux_equipment(2, False, verbose=True)
+# Toggle aux3 with verbose packet output
+success = controller.toggle_aux_equipment(3, verbose=True)
 ```
 
 ##### get_status(timeout: float = 10.0) -> Optional[dict]
@@ -314,6 +349,46 @@ All temperatures provided in both Celsius and Fahrenheit:
 - `1100` (12): 3820 System
 - `1110` (14): 3830 System
 
+## Auxiliary Equipment Protocol Details
+
+### Toggle-Based Hardware Protocol
+
+The Compool LX3xxx controllers use a **toggle-based protocol** for auxiliary equipment control, not absolute ON/OFF commands. Understanding this is crucial for proper implementation:
+
+**How Toggle Protocol Works:**
+1. **Command packets contain toggle bits** - Set bits indicate "toggle these circuits"
+2. **Hardware toggles the specified circuits** - ON circuits turn OFF, OFF circuits turn ON  
+3. **No absolute state setting** - You cannot directly set "all circuits to this exact state"
+
+**Packet Format for Aux Commands:**
+- **Primary Equipment Byte (byte 8)**: Contains toggle bits for aux1-aux8
+- **Enable Bits (byte 14)**: Bit 2 must be set to enable primary equipment field
+- **Only set bits for circuits to toggle** - Leave other bits as 0
+
+**Example Toggle Commands:**
+```python
+# Toggle aux1 only (bit 0)
+primary_equip = 0x01  # Binary: 00000001
+enable_bits = 0x04    # Bit 2 set
+
+# Toggle aux3 only (bit 2) 
+primary_equip = 0x04  # Binary: 00000100
+enable_bits = 0x04    # Bit 2 set
+
+# Toggle aux1 and aux4 simultaneously (bits 0 and 3)
+primary_equip = 0x09  # Binary: 00001001
+enable_bits = 0x04    # Bit 2 set
+```
+
+**Why Smart Toggle Logic is Needed:**
+Since hardware only supports toggling, the library implements intelligent behavior:
+1. **Read current state** from heartbeat packets (`aux1_on`, `aux2_on`, etc.)
+2. **Compare with desired state** to determine if toggle is needed
+3. **Send toggle command** only if current ≠ desired
+4. **Skip command** if already in desired state (no-op)
+
+This provides the expected "set to ON/OFF" behavior while working with toggle-only hardware.
+
 ## Protocol Functions
 
 ### Temperature Conversion
@@ -341,10 +416,10 @@ packet = create_command_packet(
     enable_bits=1 << 5  # Enable pool temperature field
 )
 
-# Create command packet for auxiliary equipment
+# Create command packet for auxiliary equipment (toggle aux3)
 packet = create_command_packet(
-    primary_equip=0x04,  # Turn on aux1 (bit 2)
-    enable_bits=1 << 0   # Enable primary equipment field
+    primary_equip=0x04,  # Toggle aux3 (bit 2 set)
+    enable_bits=1 << 2   # Enable primary equipment field (bit 2)
 )
 
 # Parse heartbeat packet
@@ -397,9 +472,9 @@ compoolctl set-spa 104f --verbose
 compoolctl set-heater heater pool
 compoolctl set-heater solar-only spa
 
-# Control auxiliary equipment
-compoolctl set-aux aux1 on
-compoolctl set-aux aux2 off --verbose
+# Control auxiliary equipment (smart toggle - only sends command if needed)
+compoolctl set-aux aux1 on      # Turn on aux1 (only if currently off)
+compoolctl set-aux aux2 off --verbose  # Turn off aux2 (only if currently on)
 
 # Monitor heartbeat packets
 compoolctl monitor --verbose
@@ -437,16 +512,26 @@ controller.set_heater_mode('off', 'pool')
 
 ### Auxiliary Equipment Control
 ```python
-# Turn on auxiliary equipment
-controller.set_aux_equipment(1, True)   # Turn on aux1
-controller.set_aux_equipment(3, True)   # Turn on aux3
+# Smart toggle - only sends command if current state differs from desired
+controller.set_aux_equipment(1, True)   # Turn on aux1 (only if off)
+controller.set_aux_equipment(3, True)   # Turn on aux3 (only if off)
 
 # Turn off auxiliary equipment
-controller.set_aux_equipment(2, False)  # Turn off aux2
+controller.set_aux_equipment(2, False)  # Turn off aux2 (only if on)
 
-# Check result
+# Direct toggle - always sends toggle command
+controller.toggle_aux_equipment(1)      # Always toggle aux1
+controller.toggle_aux_equipment(4)      # Always toggle aux4
+
+# Check result (True = success or no-op, False = command failed)
 if controller.set_aux_equipment(1, True):
-    print("Aux1 turned on successfully")
+    print("Aux1 is now on (or was already on)")
+
+# Get status to see what actually happened
+status = controller.get_status()
+if status:
+    aux1_state = "ON" if status.get('aux1_on', False) else "OFF"
+    print(f"Aux1 is currently {aux1_state}")
 ```
 
 ### Status Monitoring
@@ -488,6 +573,14 @@ controller.set_pool_temperature('80f')
 3. **Temperature Conversion**: Use proper format (`'80f'` or `'26.7c'`)
 4. **Network Delays**: Use longer timeouts for network serial bridges
 5. **Buffered Packets**: Monitor reads 24-byte chunks to handle buffering
+6. **Aux Equipment Not Responding**: 
+   - Ensure you're using the correct toggle protocol (enable bit 2, not bit 0)
+   - Verify current state reading from heartbeat packets
+   - Use `toggle_aux_equipment()` to test direct toggle commands
+7. **Unexpected Aux Behavior**:
+   - Remember hardware only supports toggling, not absolute states
+   - Use `get_status()` to verify actual equipment state after commands
+   - Check for "no action needed" messages when already in desired state
 
 ### Debug Output
 Enable verbose mode to see raw packet data:

--- a/src/pycompool/controller.py
+++ b/src/pycompool/controller.py
@@ -199,6 +199,9 @@ class PoolController:
         """
         Set the state of an auxiliary equipment circuit.
 
+        The hardware only supports toggling, so this method reads the current state
+        and only sends a toggle command if the current state differs from desired state.
+
         Args:
             aux_num: Auxiliary circuit number (1-8)
             state: True to turn on, False to turn off
@@ -222,24 +225,24 @@ class PoolController:
         if not (1 <= aux_num <= 8):
             raise ValueError(f"Invalid aux number '{aux_num}'. Must be 1-8.")
 
-        # Map aux number to bit position
-        # aux1 = bit 0, aux2 = bit 1, etc. (3820 system layout)
-        bit_position = aux_num - 1
-
-        # Get current status to preserve other equipment states
+        # Get current status to check if toggle is needed
         current_status = self.get_status(timeout=2.0)
-        current_primary_equip = 0
-
-        if current_status:
-            # Extract current primary equipment byte from hex string
-            primary_hex = current_status.get('primary_equip', '0x00')
-            current_primary_equip = int(primary_hex, 16)
-
-        # Set or clear the bit for this aux circuit
-        if state:
-            primary_equip = current_primary_equip | (1 << bit_position)
+        if not current_status:
+            print("⚠️  Could not read current status - sending toggle command anyway")
+            current_aux_state = None
         else:
-            primary_equip = current_primary_equip & ~(1 << bit_position)
+            # Check current aux state from heartbeat packet
+            current_aux_state = current_status.get(f'aux{aux_num}_on', False)
+
+        # Only toggle if current state differs from desired state
+        if current_aux_state is not None and current_aux_state == state:
+            print(f"Aux{aux_num} already {'ON' if state else 'OFF'} — no action needed")
+            return True
+
+        # Send toggle command - only set the bit for this specific aux circuit
+        # The hardware interprets set bits as "toggle this circuit"
+        bit_position = aux_num - 1
+        primary_equip = 1 << bit_position  # Only the aux bit, not full state
 
         # Use bit 2 to enable primary equipment field
         enable_bits = 1 << 2
@@ -254,8 +257,60 @@ class PoolController:
 
         success = self.connection.send_packet(packet)
 
-        print(f"Aux{aux_num} → {'ON' if state else 'OFF'} — "
-              f"{'✓ ACK' if success else '✗ NO ACK'}")
+        if current_aux_state is not None:
+            print(f"Aux{aux_num} {current_aux_state and 'ON' or 'OFF'} → {'ON' if state else 'OFF'} — "
+                  f"{'✓ ACK' if success else '✗ NO ACK'}")
+        else:
+            print(f"Aux{aux_num} → {'ON' if state else 'OFF'} — "
+                  f"{'✓ ACK' if success else '✗ NO ACK'}")
+
+        return success
+
+    def toggle_aux_equipment(self, aux_num: int, verbose: bool = False) -> bool:
+        """
+        Toggle an auxiliary equipment circuit regardless of current state.
+
+        This method always sends a toggle command, matching the Node.js behavior.
+        Use this when you want to toggle without checking current state.
+
+        Args:
+            aux_num: Auxiliary circuit number (1-8)
+            verbose: Enable verbose output
+
+        Returns:
+            True if command was acknowledged, False otherwise
+
+        Example:
+            >>> controller = PoolController()
+            >>> controller.toggle_aux_equipment(1)  # Toggle aux1
+            True
+        """
+        # Check if system is in service mode
+        if self._check_service_mode():
+            return False
+
+        # Validate aux number
+        if not (1 <= aux_num <= 8):
+            raise ValueError(f"Invalid aux number '{aux_num}'. Must be 1-8.")
+
+        # Send toggle command - only set the bit for this specific aux circuit
+        bit_position = aux_num - 1
+        primary_equip = 1 << bit_position  # Only the aux bit, not full state
+
+        # Use bit 2 to enable primary equipment field
+        enable_bits = 1 << 2
+
+        packet = create_command_packet(
+            primary_equip=primary_equip,
+            enable_bits=enable_bits
+        )
+
+        if verbose:
+            print(f"→ {packet.hex(' ')}")
+
+        success = self.connection.send_packet(packet)
+
+        print(f"Aux{aux_num} TOGGLE — {'✓ ACK' if success else '✗ NO ACK'}")
 
         return success
 

--- a/src/pycompool/controller.py
+++ b/src/pycompool/controller.py
@@ -228,14 +228,13 @@ class PoolController:
         # Get current status to check if toggle is needed
         current_status = self.get_status(timeout=2.0)
         if not current_status:
-            print("⚠️  Could not read current status - sending toggle command anyway")
-            current_aux_state = None
-        else:
-            # Check current aux state from heartbeat packet
-            current_aux_state = current_status.get(f'aux{aux_num}_on', False)
+            return False
+
+        # Check current aux state from heartbeat packet
+        current_aux_state = current_status.get(f'aux{aux_num}_on', False)
 
         # Only toggle if current state differs from desired state
-        if current_aux_state is not None and current_aux_state == state:
+        if current_aux_state == state:
             print(f"Aux{aux_num} already {'ON' if state else 'OFF'} — no action needed")
             return True
 
@@ -257,12 +256,8 @@ class PoolController:
 
         success = self.connection.send_packet(packet)
 
-        if current_aux_state is not None:
-            print(f"Aux{aux_num} {current_aux_state and 'ON' or 'OFF'} → {'ON' if state else 'OFF'} — "
-                  f"{'✓ ACK' if success else '✗ NO ACK'}")
-        else:
-            print(f"Aux{aux_num} → {'ON' if state else 'OFF'} — "
-                  f"{'✓ ACK' if success else '✗ NO ACK'}")
+        print(f"Aux{aux_num} {current_aux_state and 'ON' or 'OFF'} → {'ON' if state else 'OFF'} — "
+              f"{'✓ ACK' if success else '✗ NO ACK'}")
 
         return success
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -397,7 +397,7 @@ class TestPoolController:
 
         # Mock get_status to return current state
         with patch.object(PoolController, 'get_status') as mock_status:
-            mock_status.return_value = {'primary_equip': '0x00'}  # No equipment on
+            mock_status.return_value = {'aux1_on': False}  # Aux1 currently OFF
 
             controller = PoolController()
             result = controller.set_aux_equipment(1, True)
@@ -405,9 +405,9 @@ class TestPoolController:
             assert result is True
             mock_connection.send_packet.assert_called_once()
 
-            # Check output
+            # Check output (new format shows current → desired)
             captured = capsys.readouterr()
-            assert "Aux1 → ON — ✓ ACK" in captured.out
+            assert "Aux1 OFF → ON — ✓ ACK" in captured.out
 
     @patch('pycompool.controller.SerialConnection')
     def test_set_aux_equipment_failure(self, mock_connection_class, capsys):
@@ -417,16 +417,16 @@ class TestPoolController:
         mock_connection.send_packet.return_value = False
 
         with patch.object(PoolController, 'get_status') as mock_status:
-            mock_status.return_value = {'primary_equip': '0x04'}  # aux1 on
+            mock_status.return_value = {'aux1_on': True}  # Aux1 currently ON
 
             controller = PoolController()
             result = controller.set_aux_equipment(1, False)
 
             assert result is False
 
-            # Check output
+            # Check output (toggle command sent but failed)
             captured = capsys.readouterr()
-            assert "Aux1 → OFF — ✗ NO ACK" in captured.out
+            assert "Aux1 ON → OFF — ✗ NO ACK" in captured.out
 
     @patch('pycompool.controller.SerialConnection')
     def test_set_aux_equipment_verbose(self, mock_connection_class, capsys):
@@ -436,7 +436,7 @@ class TestPoolController:
         mock_connection.send_packet.return_value = True
 
         with patch.object(PoolController, 'get_status') as mock_status:
-            mock_status.return_value = {'primary_equip': '0x00'}
+            mock_status.return_value = {'aux2_on': False}  # Aux2 currently OFF
 
             controller = PoolController()
             result = controller.set_aux_equipment(2, True, verbose=True)
@@ -446,7 +446,7 @@ class TestPoolController:
             # Check verbose output shows packet hex
             captured = capsys.readouterr()
             assert "→" in captured.out  # Packet hex output
-            assert "Aux2 → ON" in captured.out
+            assert "Aux2 OFF → ON" in captured.out
 
     def test_set_aux_equipment_invalid_aux_number(self):
         """Test invalid aux number raises ValueError."""
@@ -460,45 +460,68 @@ class TestPoolController:
 
     @patch('pycompool.controller.SerialConnection')
     def test_aux_equipment_packet_content(self, mock_connection_class):
-        """Test that aux equipment packet has correct content."""
+        """Test that aux equipment packet has correct content for toggle command."""
         mock_connection = Mock()
         mock_connection_class.return_value = mock_connection
         mock_connection.send_packet.return_value = True
 
         with patch.object(PoolController, 'get_status') as mock_status:
-            mock_status.return_value = {'primary_equip': '0x00'}
+            # Mock aux1 as OFF, so turning it ON will send toggle command
+            mock_status.return_value = {'aux1_on': False}
 
             controller = PoolController()
 
-            # Test turning on aux1 (bit 0)
+            # Test turning on aux1 - should send toggle since it's currently OFF
             controller.set_aux_equipment(1, True)
 
-            # Verify packet structure
+            # Verify packet structure - should only set bit 0 for aux1 toggle
             call_args = mock_connection.send_packet.call_args[0][0]
             assert len(call_args) == 17  # Command packet length
             assert call_args[:2] == b"\xFF\xAA"  # Sync bytes
-            assert call_args[8] == 0x01  # Primary equip byte (bit 0 set)
+            assert call_args[8] == 0x01  # Primary equip byte (bit 0 set for aux1)
             assert call_args[14] == 0x04  # Enable bit 2 for primary equip
 
     @patch('pycompool.controller.SerialConnection')
-    def test_aux_equipment_preserves_other_states(self, mock_connection_class):
-        """Test that aux equipment control preserves other equipment states."""
+    def test_aux_equipment_no_op_when_already_in_desired_state(self, mock_connection_class):
+        """Test that aux equipment doesn't send command when already in desired state."""
         mock_connection = Mock()
         mock_connection_class.return_value = mock_connection
         mock_connection.send_packet.return_value = True
 
         with patch.object(PoolController, 'get_status') as mock_status:
-            # Mock existing state with aux2 already on (bit 1 = 0x02)
-            mock_status.return_value = {'primary_equip': '0x02'}
+            # Mock aux1 as already ON
+            mock_status.return_value = {'aux1_on': True}
 
             controller = PoolController()
 
-            # Turn on aux1 while aux2 is already on
-            controller.set_aux_equipment(1, True)
+            # Try to turn on aux1 when it's already on - should be no-op
+            result = controller.set_aux_equipment(1, True)
 
-            # Verify packet preserves aux2 and adds aux1
+            # Should return True but not send any packet
+            assert result is True
+            mock_connection.send_packet.assert_not_called()
+
+    @patch('pycompool.controller.SerialConnection')
+    def test_aux_equipment_toggle_method(self, mock_connection_class):
+        """Test that toggle_aux_equipment always sends toggle command."""
+        mock_connection = Mock()
+        mock_connection_class.return_value = mock_connection
+        mock_connection.send_packet.return_value = True
+
+        with patch.object(PoolController, '_check_service_mode') as mock_service:
+            mock_service.return_value = False
+
+            controller = PoolController()
+
+            # Test toggling aux3
+            controller.toggle_aux_equipment(3)
+
+            # Verify packet structure - should set bit 2 for aux3
             call_args = mock_connection.send_packet.call_args[0][0]
-            assert call_args[8] == 0x03  # Both aux1 (bit 0) and aux2 (bit 1) on
+            assert len(call_args) == 17  # Command packet length
+            assert call_args[:2] == b"\xFF\xAA"  # Sync bytes
+            assert call_args[8] == 0x04  # Primary equip byte (bit 2 set for aux3)
+            assert call_args[14] == 0x04  # Enable bit 2 for primary equip
 
 
 class TestServiceModeProtection:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -523,6 +523,25 @@ class TestPoolController:
             assert call_args[8] == 0x04  # Primary equip byte (bit 2 set for aux3)
             assert call_args[14] == 0x04  # Enable bit 2 for primary equip
 
+    @patch('pycompool.controller.SerialConnection')
+    def test_aux_equipment_fails_when_status_unavailable(self, mock_connection_class):
+        """Test that aux equipment returns False when current status can't be read."""
+        mock_connection = Mock()
+        mock_connection_class.return_value = mock_connection
+
+        with patch.object(PoolController, 'get_status') as mock_status:
+            # Mock get_status to return None (status unavailable)
+            mock_status.return_value = None
+
+            controller = PoolController()
+
+            # Should return False when status can't be read
+            result = controller.set_aux_equipment(1, True)
+
+            assert result is False
+            # No packet should be sent
+            mock_connection.send_packet.assert_not_called()
+
 
 class TestServiceModeProtection:
     """Test service mode safety checks across all command methods."""


### PR DESCRIPTION
## Summary
- **Fix fundamental protocol issue**: Hardware only supports toggling, not absolute ON/OFF states
- **Smart toggle logic**: Only send toggle command when current state ≠ desired state  
- **Correct packet format**: Send only specific aux bit (like Node.js), not full equipment byte
- **Add toggle method**: `toggle_aux_equipment()` for direct toggle operations
- **Better UX**: Shows "Aux1 OFF → ON" status transitions and no-op when already in desired state

## Root Cause
The previous implementation tried to set absolute states by sending the full equipment byte with all circuits, but the hardware protocol expects individual bits to indicate "toggle these specific circuits".

## Solution  
- Read current aux state from heartbeat packets (`aux1_on`, `aux2_on`, etc.)
- Compare with desired state to determine if toggle is needed
- Send `primary_equip = 1 << (aux_num-1)` (only target aux bit) 
- Return early when already in desired state (no unnecessary commands)

## Test Plan
- [x] All existing tests updated and passing
- [x] New tests for no-op behavior and toggle method
- [x] Packet content validation confirms correct bit patterns
- [x] Code passes linting and type checking

**This should fix the ACK issues with aux equipment commands by using the correct toggle-based protocol that matches the working Node.js implementation.**

🤖 Generated with [Claude Code](https://claude.ai/code)