### PR TITLE
Fix spa heater control by preserving heat source settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Spa heater control now works correctly**
+  - Fixed issue where `set_heater off spa` was failing with "NO ACK" error
+  - Heat source byte now preserves existing pool/spa settings when updating specific target
+  - Uses proper bit masking to update only pool bits (4-5) or spa bits (6-7) independently
+  - Added heat source state parsing from heartbeat packets
+
 ## [0.2.2] - 2025-09-12
 
 ### Fixed

--- a/src/pycompool/controller.py
+++ b/src/pycompool/controller.py
@@ -170,13 +170,22 @@ class PoolController:
             'solar-only': 0b11
         }
 
-        # Calculate heat source byte
+        # Get current heat source state to preserve other target's settings
+        current_status = self.get_status(timeout=2.0)
+        if current_status:
+            current_heat_source = current_status.get('delay_heat_source_byte', 0)
+        else:
+            # If we can't read current state, start with zero (fail open)
+            current_heat_source = 0
+
+        # Calculate heat source byte by preserving existing settings
         # Pool uses bits 4-5, Spa uses bits 6-7
-        heat_source = 0
         if target == 'pool':
-            heat_source = mode_bits[mode] << 4  # Bits 4-5
+            # Clear pool bits (4-5) but preserve spa bits (6-7) and delay bits (0-3)
+            heat_source = (current_heat_source & 0b11001111) | (mode_bits[mode] << 4)
         else:  # spa
-            heat_source = mode_bits[mode] << 6  # Bits 6-7
+            # Clear spa bits (6-7) but preserve pool bits (4-5) and delay bits (0-3)
+            heat_source = (current_heat_source & 0b00111111) | (mode_bits[mode] << 6)
 
         enable_bits = 1 << 4  # Enable heat source field (bit 4)
 

--- a/src/pycompool/protocol.py
+++ b/src/pycompool/protocol.py
@@ -139,7 +139,7 @@ def parse_heartbeat_packet(data: bytes) -> Optional[dict]:
     minutes, hours = data[6], data[7]
     primary_equip = data[8]
     secondary_equip = data[9]
-    data[10]
+    delay_heat_source = data[10]  # Delay/Heat source byte
     water_temp = data[11]  # Pool water temp in 0.25°C
     solar_temp = data[12]  # Pool solar temp in 0.5°C
     spa_water_temp = data[13]  # Spa water temp in 0.25°C (3830 only)
@@ -161,6 +161,10 @@ def parse_heartbeat_packet(data: bytes) -> Optional[dict]:
         'solar_on': bool(secondary_equip & 0x04),
         'remotes_enabled': bool(secondary_equip & 0x08),
         'freeze_mode': bool(secondary_equip & 0x80),
+        # Heat source settings (bits 4-7 of delay_heat_source byte)
+        'pool_heat_source': (delay_heat_source >> 4) & 0x03,  # Bits 4-5
+        'spa_heat_source': (delay_heat_source >> 6) & 0x03,   # Bits 6-7
+        'delay_heat_source_byte': delay_heat_source,  # Raw byte for debugging
         # Primary equipment state (auxiliary circuits - 3820 system layout)
         'aux1_on': bool(primary_equip & 0x01),     # Bit 0
         'aux2_on': bool(primary_equip & 0x02),     # Bit 1

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -180,6 +180,8 @@ class TestPoolController:
         mock_connection.send_packet.return_value = True
 
         controller = PoolController()
+        # Mock get_status to return a status with heat source byte
+        controller.get_status = Mock(return_value={'delay_heat_source_byte': 0x00})
         result = controller.set_heater_mode("heater", "pool")
 
         assert result is True
@@ -197,6 +199,8 @@ class TestPoolController:
         mock_connection.send_packet.return_value = False
 
         controller = PoolController()
+        # Mock get_status to return a status with heat source byte
+        controller.get_status = Mock(return_value={'delay_heat_source_byte': 0x00})
         result = controller.set_heater_mode("solar-only", "spa")
 
         assert result is False
@@ -213,6 +217,8 @@ class TestPoolController:
         mock_connection.send_packet.return_value = True
 
         controller = PoolController()
+        # Mock get_status to return a status with heat source byte
+        controller.get_status = Mock(return_value={'delay_heat_source_byte': 0x00})
         result = controller.set_heater_mode("off", "pool", verbose=True)
 
         assert result is True
@@ -244,6 +250,8 @@ class TestPoolController:
         mock_connection.send_packet.return_value = True
 
         controller = PoolController()
+        # Mock get_status to return a status with heat source byte
+        controller.get_status = Mock(return_value={'delay_heat_source_byte': 0x00})
 
         # Test each mode for pool
         test_cases = [
@@ -272,6 +280,8 @@ class TestPoolController:
         mock_connection.send_packet.return_value = True
 
         controller = PoolController()
+        # Mock get_status to return a status with heat source byte
+        controller.get_status = Mock(return_value={'delay_heat_source_byte': 0x00})
 
         # Test each mode for spa
         test_cases = [

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "pycompool"
-version = "0.1.2"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary
- Fixes issue where `compoolctl set_heater off spa` was failing with "NO ACK" error while pool heater control worked fine
- Root cause: Heat source byte was being overwritten entirely instead of preserving existing pool/spa settings
- Solution: Read current state and use bit masking to update only the target's bits (pool=4-5, spa=6-7)

## Changes Made
- **Protocol parsing**: Extract heat source state from heartbeat packets (byte 10)
- **Controller logic**: Preserve existing heat source settings when updating specific target
- **Test updates**: Mock `get_status()` method calls in heater mode tests
- **Documentation**: Updated CHANGELOG.md with fix details

## Test Plan
- [x] Verify `set_heater off spa` now works (was failing before)
- [x] Verify `set_heater off pool` still works (was working before) 
- [x] Test various mode combinations to ensure independence
- [x] All existing tests pass with updated mocks
- [x] Linting and type checking pass

## Technical Details
The heat source byte (byte 10 in command packets) uses:
- Bits 4-5: Pool heat source setting
- Bits 6-7: Spa heat source setting

Previously, the code was setting `heat_source = 0` and then only updating the target bits, which accidentally cleared the other target's settings. Now it reads the current state first and uses bit masking to preserve existing settings.

🤖 Generated with [Claude Code](https://claude.ai/code)