### PR TITLE
chore: sync v0.2.3 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2025-09-12
+
 ### Fixed
 - **Spa heater control now works correctly**
   - Fixed issue where `set_heater off spa` was failing with "NO ACK" error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycompool"
-version = "0.2.2"
+version = "0.2.3"
 description = "Control Pentair/Compool LX3xxx pool and spa systems via RS-485"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pycompool/__init__.py
+++ b/src/pycompool/__init__.py
@@ -9,5 +9,5 @@ from .connection import ConnectionError
 from .controller import PoolController
 from .protocol import PacketType, ProtocolError
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __all__ = ["PoolController", "ProtocolError", "PacketType", "ConnectionError"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "pycompool"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
## Summary
- update package metadata to match the existing v0.2.3 release tag
- mark the spa heater fix changelog section as 0.2.3

## Checks
- uv run ruff check .
- uv run pytest

Opened by the weekly OSS maintainer run for Matt review.